### PR TITLE
avoid MCU waiting in bootloader on hardware restart

### DIFF
--- a/src/connections/pyserial.js
+++ b/src/connections/pyserial.js
@@ -43,7 +43,7 @@ export default class PySerial {
 
     var dtr_support = ['darwin']
 
-    this.dtr_supported = dtr_support.indexOf(process.platform) > -1
+    this.dtr_supported = dtr_support.indexOf(process.platform) > -1  
   }
 
   static COMPORT_MANUFACTURERS(){
@@ -201,7 +201,10 @@ export default class PySerial {
   }
 
   sendPing(cb){
-    var _this = this
+    if (process.platform == 'win32'){
+      // avoid MCU waiting in bootloader on hardware restart by setting both dtr and rts high
+      this.stream.set({rts: true})
+    }
     // not implemented
     if(this.dtr_supported){
       this.stream.set({dtr: true},function(err){


### PR DESCRIPTION
This is a proposed fix / workaround for #16 

## Where has this been tested?

note that I have not tested this with pyboards, only with generic esp32 boards

Operating system:
Windows 10 [Version 10.0.17134.285]
VSCode version:
Version: 1.27.2 (system setup)
Commit: f46c4c469d6e6d8c46f268d1553c5dc4b475840f
Date: 2018-09-12T16:17:45.060Z
Electron: 2.0.7
Chrome: 61.0.3163.100
Node.js: 8.9.3
V8: 6.1.534.41
Architecture: x64
Pymakr version:
1.0.3