### PR TITLE
Fix missing import in list_files

### DIFF
--- a/src/board/shell-workers.js
+++ b/src/board/shell-workers.js
@@ -66,7 +66,7 @@ export default class ShellWorkers {
       names = names.splice(1)
       var is_dir = current_file.indexOf('.') == -1
       if(is_dir){
-        var c = "import ubinascii,sys\r\n"
+        var c = "import ubinascii,sys,uos as os\r\n"
         c += "list = ubinascii.hexlify(str(os.listdir('"+current_file_root + "')))\r\n"
         c += "sys.stdout.write(list)\r\n"
         _this.shell.eval(c,function(err,content){


### PR DESCRIPTION
## What does this implement/fix? Explain your changes.
add a missing `import uos as os`  to the micropython code to generate a filelist.

## Does this close any currently open issues?
yes, this fixes #23 

## Any other comments?
this is just a fix for the missing import, no additional error checking has been added

## Where has this been tested?

**Operating system:**
`Microsoft Windows [Version 10.0.17763.55]`

**VSCode version:**
```
Version: 1.28.1 (system setup)
Commit: 3368db6750222d319c851f6d90eb619d886e08f5
Date: 2018-10-11T18:13:53.910Z
Electron: 2.0.9
Chrome: 61.0.3163.100
Node.js: 8.9.3
V8: 6.1.534.41
Architecture: x64
```
**Pymakr version:**
`1.0.3 `

