### PR TITLE
[dev] Add source maps to improve debugging

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -6,9 +6,12 @@
     "suppressTaskName": true,
     "tasks": [
         {
-            "taskName": "babel-build-watch",
-            "args": [ "run", "babel-build-watch" ],
-            "isBuildCommand": true
+            "type": "npm",
+            "script": "babel-build-dev",
+            "group": {
+                "kind": "build",
+                "isDefault": true
+            }
         }
     ]
 }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,13 +1,14 @@
 {
-    "version": "0.1.0",
-    "command": "npm",
-    "isShellCommand": true,
-    "showOutput": "always",
-    "suppressTaskName": true,
+    // See https://go.microsoft.com/fwlink/?LinkId=733558
+    // for the documentation about the tasks.json format
+    "version": "2.0.0",
     "tasks": [
         {
-            "type": "npm",
-            "script": "babel-build-dev",
+            "label": "Build",
+            "type": "shell",
+            "command": "${workspaceRoot}/node_modules/.bin/babel",
+            "args": ["src", "--out-dir", "lib","--source-maps","-w"],
+            "isBackground": true,
             "group": {
                 "kind": "build",
                 "isDefault": true

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,15 +1,14 @@
 {
     "version": "0.1.0",
-    "command": "${workspaceRoot}/node_modules/.bin/babel",
+    "command": "npm",
     "isShellCommand": true,
+    "showOutput": "always",
+    "suppressTaskName": true,
     "tasks": [
         {
-            "args": ["src", "--out-dir", "lib","-w"],
-            "taskName": "watch",
-            "suppressTaskName": true,
-            "isBuildCommand": true,
-            "isWatching": true
+            "taskName": "babel-build-watch",
+            "args": [ "run", "babel-build-watch" ],
+            "isBuildCommand": true
         }
-        
     ]
 }

--- a/.vscodeignore
+++ b/.vscodeignore
@@ -5,3 +5,4 @@ test/**
 jsconfig.json
 vsc-extension-quickstart.md
 .eslintrc.json
+**/*.map

--- a/package.json
+++ b/package.json
@@ -151,7 +151,7 @@
   "scripts": {
     "postinstall": "node ./node_modules/vscode/bin/install",
     "test": "node ./node_modules/vscode/bin/test",
-    "babel-watch": "babel src --out-dir lib",
+    "babel-build-watch": "babel src --out-dir lib --source-maps --watch",
     "install": "node scripts/install.js",
     "rebuild": "node scripts/rebuild.js"
   },

--- a/package.json
+++ b/package.json
@@ -151,7 +151,8 @@
   "scripts": {
     "postinstall": "node ./node_modules/vscode/bin/install",
     "test": "node ./node_modules/vscode/bin/test",
-    "babel-build-watch": "babel src --out-dir lib --source-maps --watch",
+    "babel-watch": "babel src --out-dir lib",
+    "babel-build-dev": "babel src --out-dir lib --source-maps --watch",
     "install": "node scripts/install.js",
     "rebuild": "node scripts/rebuild.js"
   },


### PR DESCRIPTION
## What does this implement/fix? Explain your changes.
This PR changes the babel transpiler settings to generate [sourcemaps](https://babeljs.io/docs/en/options#source-map-options) to allow for more effective debugging.

The sourcemaps are used to enable setting breakpoints in, and stepping though the source code, rather than though the transpiled code.

old build script :
    "babel-watch": "babel src --out-dir lib",
New build script 
    "babel-build-dev": "babel src --out-dir lib --source-maps --watch",

#Note 
The task build settings are still using an older version, as I could not get them to work in the new task schema.
