### PR TITLE
tentative fix to non-existent dependencies in package and package-lock

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,58 +1,9 @@
 {
   "name": "pymakr",
-  "version": "1.0.5",
+  "version": "1.0.7",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
-    "parser-byte-length": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/parser-byte-length/-/parser-byte-length-1.0.5.tgz",
-      "integrity": "sha512-GCz/v/KG2Wv7SdQ2nv8jYGBY6D4h5tibj9bs0+pnryCDAr8xmmvnesFW15FIu4rwOMgsKhCHyp7roD8bRGs63A==",
-      "requires": {
-        "safe-buffer": "^5.1.1"
-      }
-    },
-    "parser-cctalk": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/parser-cctalk/-/parser-cctalk-1.0.5.tgz",
-      "integrity": "sha512-VdoG1rRXb5deHM1c9Akn9djoJuHn030v7owYHEqpJeS6Rs6wrC4Hrkw8NxvV9ZPlMqAJ+5uJCaAUzB1tbVd3rA==",
-      "requires": {
-        "safe-buffer": "^5.1.1"
-      }
-    },
-    "parser-delimiter": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/parser-delimiter/-/parser-delimiter-1.0.5.tgz",
-      "integrity": "sha512-srDzeNwGM/GjtqK/nFDRIDpcZ6XDgkakFMXBtNDSI+XP6fqO1ynEZok8ljKJxM2ay0CNG83C6/X2xIOHvWhFYQ==",
-      "requires": {
-        "safe-buffer": "^5.1.1"
-      }
-    },
-    "parser-readline": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/parser-readline/-/parser-readline-1.0.5.tgz",
-      "integrity": "sha512-QkZoCQPHwdZOMQk7SHz3QSp7xqK4jdNql9M80oXqWt7kNhFvNXguWzf17FfQrPRIb0qiz+96+P6uAOIi02Yxbg==",
-      "requires": {
-        "parser-delimiter": "^1.0.5",
-        "safe-buffer": "^5.1.1"
-      }
-    },
-    "parser-ready": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/parser-ready/-/parser-ready-1.0.5.tgz",
-      "integrity": "sha512-U/ZkxyY35Z7WrDc0O8TGcGPOdwv6fGVJcZq5vXVko2MRt8wiKVD192mmbfTRZXFAX+rARXtQa3ad3yJzXVhb1g==",
-      "requires": {
-        "safe-buffer": "^5.1.1"
-      }
-    },
-    "parser-regex": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/parser-regex/-/parser-regex-1.0.5.tgz",
-      "integrity": "sha512-sX3tRuwwwGV+CZbKEUAKZD/wtG8ZRcGxbiDIm8nyzsPCGv52ck3RlQ9Vp4K8fYjcrGGwm3BWizC4uSzaTLOk1A==",
-      "requires": {
-        "safe-buffer": "^5.1.1"
-      }
-    },
     "@types/mocha": {
       "version": "2.2.48",
       "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-2.2.48.tgz",
@@ -1842,9 +1793,9 @@
       "dev": true
     },
     "duplexify": {
-      "version": "3.6.1",
-      "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.6.1.tgz",
-      "integrity": "sha512-vM58DwdnKmty+FSPzT14K9JXb90H+j5emaR4KYbr2KTIz00WHGbWOe5ghQTx233ZCLZtrGDALzKwcjEtSt35mA==",
+      "version": "3.7.1",
+      "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.7.1.tgz",
+      "integrity": "sha512-07z8uv2wMyS51kKhD1KsdXJg5WQ6t93RneqRxUHnskXVtlYYkLqM0gqStQZ3pj073g687jPCHrqNfCzawLYh5g==",
       "dev": true,
       "requires": {
         "end-of-stream": "^1.0.0",
@@ -2168,7 +2119,7 @@
     },
     "event-stream": {
       "version": "3.3.4",
-      "resolved": "https://registry.npmjs.org/event-stream/-/event-stream-3.3.4.tgz",
+      "resolved": "http://registry.npmjs.org/event-stream/-/event-stream-3.3.4.tgz",
       "integrity": "sha1-SrTJoPWlTbkzi0w02Gv86PSzVXE=",
       "dev": true,
       "requires": {
@@ -2345,13 +2296,13 @@
       }
     },
     "flush-write-stream": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/flush-write-stream/-/flush-write-stream-1.0.3.tgz",
-      "integrity": "sha512-calZMC10u0FMUqoiunI2AiGIIUtUIvifNwkHhNupZH4cbNnW1Itkoh/Nf5HFYmDrwWPjrUxpkZT0KhuCq0jmGw==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/flush-write-stream/-/flush-write-stream-1.1.1.tgz",
+      "integrity": "sha512-3Z4XhFZ3992uIq0XOqb9AreonueSYphE6oYbpt5+3u06JWklbsPkNv3ZKkP9Bz/r+1MWCaMoSQ28P85+1Yc77w==",
       "dev": true,
       "requires": {
-        "inherits": "^2.0.1",
-        "readable-stream": "^2.0.4"
+        "inherits": "^2.0.3",
+        "readable-stream": "^2.3.6"
       }
     },
     "for-in": {
@@ -4364,7 +4315,7 @@
     },
     "ncp": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ncp/-/ncp-2.0.0.tgz",
+      "resolved": "http://registry.npmjs.org/ncp/-/ncp-2.0.0.tgz",
       "integrity": "sha1-GVoh1sRuNh0vsSgbo4uR6d9727M="
     },
     "next-tick": {
@@ -5672,56 +5623,6 @@
       "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz",
       "integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA=="
     },
-    "serialport": {
-      "version": "6.2.2",
-      "resolved": "https://registry.npmjs.org/serialport/-/serialport-6.2.2.tgz",
-      "integrity": "sha512-BQqTR06ZXKwKB6rUjeANm3aIZo0rqNbQsrQX5zKEDcNY4rxiu5dvdcfIOaAGuZkhW7jAKJsgKC5TjeURtLVuOQ==",
-      "requires": {
-        "parser-byte-length": "^1.0.5",
-        "parser-cctalk": "^1.0.5",
-        "parser-delimiter": "^1.0.5",
-        "parser-readline": "^1.0.5",
-        "parser-ready": "^1.0.5",
-        "parser-regex": "^1.0.5",
-        "bindings": "1.3.0",
-        "commander": "^2.13.0",
-        "debug": "^3.1.0",
-        "nan": "^2.9.2",
-        "prebuild-install": "^4.0.0",
-        "promirepl": "^1.0.1",
-        "prompt-list": "^3.2.0",
-        "safe-buffer": "^5.1.2"
-      },
-      "dependencies": {
-        "minimist": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
-        },
-        "prebuild-install": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-4.0.0.tgz",
-          "integrity": "sha512-7tayxeYboJX0RbVzdnKyGl2vhQRWr6qfClEXDhOkXjuaOKCw2q8aiuFhONRYVsG/czia7KhpykIlI2S2VaPunA==",
-          "requires": {
-            "detect-libc": "^1.0.3",
-            "expand-template": "^1.0.2",
-            "github-from-package": "0.0.0",
-            "minimist": "^1.2.0",
-            "mkdirp": "^0.5.1",
-            "node-abi": "^2.2.0",
-            "noop-logger": "^0.1.1",
-            "npmlog": "^4.0.1",
-            "os-homedir": "^1.0.1",
-            "pump": "^2.0.1",
-            "rc": "^1.1.6",
-            "simple-get": "^2.7.0",
-            "tar-fs": "^1.13.0",
-            "tunnel-agent": "^0.6.0",
-            "which-pm-runs": "^1.0.0"
-          }
-        }
-      }
-    },
     "set-blocking": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
@@ -5860,7 +5761,7 @@
     },
     "spdx-correct": {
       "version": "3.0.0",
-      "resolved": "http://registry.npmjs.org/spdx-correct/-/spdx-correct-3.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.0.0.tgz",
       "integrity": "sha512-N19o9z5cEyc8yQQPukRCZ9EUmb4HUpnrmaL/fxS2pBo2jbfcFRVuFZ/oFC+vZz0MNNk0h80iMn5/S6qGZOL5+g==",
       "requires": {
         "spdx-expression-parse": "^3.0.0",
@@ -6682,9 +6583,9 @@
       }
     },
     "vscode": {
-      "version": "1.1.26",
-      "resolved": "https://registry.npmjs.org/vscode/-/vscode-1.1.26.tgz",
-      "integrity": "sha512-z1Nf5J38gjUFbuDCbJHPN6OJ//5EG+e/yHlh6ERxj/U9B2Qc3aiHaFr38/fee/GGnxvRw/XegLMOG+UJwKi/Qg==",
+      "version": "1.1.30",
+      "resolved": "https://registry.npmjs.org/vscode/-/vscode-1.1.30.tgz",
+      "integrity": "sha512-YDj5w0TGOcS8XLIdekT4q6LlLV6hv1ZvuT2aGT3KJll4gMz6dUPDgo2VVAf0i0E8igbbZthwvmaUGRwW9yPIaw==",
       "dev": true,
       "requires": {
         "glob": "^7.1.2",
@@ -6752,9 +6653,9 @@
           "dev": true
         },
         "source-map-support": {
-          "version": "0.5.10",
-          "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.10.tgz",
-          "integrity": "sha512-YfQ3tQFTK/yzlGJuX8pTwa4tifQj4QS2Mj7UegOu8jAz59MqIiMGPXxQhVQiIMNzayuUSF/jEuVnfFF5JqybmQ==",
+          "version": "0.5.11",
+          "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.11.tgz",
+          "integrity": "sha512-//sajEx/fGL3iw6fltKMdPvy8kL3kJ2O3iuYlRoT3k9Kb4BjOoZ+BZzaNHeuaruSt+Kf3Zk9tnfAQg9/AJqUVQ==",
           "dev": true,
           "requires": {
             "buffer-from": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "theme": "light"
   },
   "engines": {
-    "vscode": "^1.11.0"
+    "vscode": "^1.31.0"
   },
   "keywords": [
     "pycom",
@@ -211,6 +211,6 @@
     "eslint": "^3.6.0",
     "mocha": "^5.2.0",
     "vsce": "^1.35.0",
-    "vscode": "^1.1.26"
+    "vscode": "^1.1.30"
   }
 }


### PR DESCRIPTION
## What does this implement/fix? Explain your changes.

This seems to fix #34 , however I have needed to :


manually remove references to the non-exeisten dependent 1.0.5 versions from both
** package.json
** package-lock.json
Any other comments?
this does not seem a good way to fix this , on the other hand not being able to build and package the solution is not acceptable either.
as I do no understand in detail how the serial library was rebuild in v1.0.6 37c243d ; this seems to be an acceptable solution.
It should also be checked that this has no ill effects on the building of the seriallib.
also ; when I run vsce package this creates a serialport.node file in the /output folder ; but not sure how to use / verify this.

#Where has this been tested?
only on my machine :-)


