### PR TITLE
Added callback to pymakr.js

### DIFF
--- a/pymakr.js
+++ b/pymakr.js
@@ -150,6 +150,7 @@ function prepareSerialPort(cb){
     }catch(e){
         console.log("Error while loading serialport library")
         console.log(e)
+        cb(e)
         // FIXME: install.js has been removed, the below just treid to re-copy 
         // var exec = require('child_process').exec
         // var cmd = 'npx electron-rebuild --force --version '+ process.versions['electron'];


### PR DESCRIPTION
Added callback to pymakr.js file when it fails to load serialport, so that vscode shows an visual error.

(Hi! 👋 Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)

## What does this implement/fix? Explain your changes.
Currently vscode only shows an error in the developer console if pymakr extension fails to load the serialport module.
It took me a long time to figure out that the extension failed to load.

## Does this close any currently open issues?
No

## Any relevant logs, error output, etc?
No

## Any other comments?


## Where has this been tested?

**Operating system:**
Windows 10	10.0.19041 Build 19041

**VSCode version:**
1.51.0

**Pymakr version:**
1.1.7