### PR TITLE
Release v1.1.14

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -12,7 +12,7 @@ jobs:
   build:
     strategy:
       matrix:
-        os: [macos-latest, ubuntu-latest, windows-latest]
+        os: [ubuntu-latest]
     runs-on: ${{ matrix.os }}
     steps:
     - name: Checkout

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,30 @@
+name: Deploy PyMakr
+
+on:
+  push:
+    branches:
+    - master
+  release:
+    types:
+    - created
+
+jobs:
+  build:
+    strategy:
+      matrix:
+        os: [macos-latest, ubuntu-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+    - name: Install Node.js
+      uses: actions/setup-node@v1
+      with:
+        node-version: 14
+    - run: npm ci
+    
+    - name: Publish
+      if: success() && startsWith( github.ref, 'refs/tags/releases/') && matrix.os == 'ubuntu-latest'
+      run: npm run deploy
+      env:
+        VSCE_PAT: ${{ secrets.PUBLISHER_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,4 @@
-name: Build Pymakr
+name: Test Pymakr
 
 on:
   pull_request: ~

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# Changelog
+
+
+## [1.1.14](https://github.com/pycom/pymakr-vsc/compare/release-v1.1.13...release-v1.1.14) (2021-10-11)
+- fix Node build tools are no longer a requirement
+
 ## 1.1.12 - Compatibility vscode 1.53
 - fix serialports binding for new vscode 1.56.0
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pymakr",
-  "version": "1.1.14-beta.0",
+  "version": "1.1.14",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "pymakr",
-      "version": "1.1.14-beta.0",
+      "version": "1.1.14",
       "license": "SEE LICENSE IN <LICENSE.md>",
       "dependencies": {
         "binascii": "0.0.2",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "pymakr",
   "displayName": "Pymakr",
   "description": "Adds a REPL console to the terminal that connects to your Pycom board. Run single files or synchronize your project files to your board.",
-  "version": "1.1.14-beta.1",
+  "version": "1.1.14",
   "publisher": "pycom",
   "repository": "https://github.com/pycom/pymakr-vsc",
   "icon": "images/logo.png",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,8 @@
   "scripts": {
     "test": "node ./test/runTest.js",
     "package": "vsce package",
-    "vscode:prepublish": "npm ci && npm prune"
+    "vscode:prepublish": "npm ci && npm prune",
+    "deploy": "vsce publish"
   },
   "contributes": {
     "commands": [


### PR DESCRIPTION
This PR should remove any dependencies for NPM and node build tools on the host machine.

- Added [custom implementation](https://github.com/pycom/pymakr-vsc/pull/158/commits/fa7be26ac67d0dedd4c18ac1e00a11662d0a3656) of [prebuild-install](https://www.npmjs.com/package/prebuild-install)
- Removed dependencies for build tools on host
- Replaced unit test with integration tests which run in an instance VSCode (ensures Electron version is correct)
- Cleaned up and simplified the package further
  - cleaned up conflicting specification standards
  - removed unnecessary babel build steps
  - removed bindings builder and added auto downloader https://github.com/pycom/pymakr-vsc/commit/fa7be26ac67d0dedd4c18ac1e00a11662d0a3656