### PR TITLE
chore: fix missing github token

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -20,3 +20,4 @@ jobs:
         run: npm run semantic-release -- --dry-run --debug
         env:
           VSCE_PAT: ${{ secrets.PUBLISHER_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
According to documentation, a GITHUB_TOKEN should be automatically created when running Github Actions.