### PR TITLE
Omit-dry-run-from-release-script

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -19,7 +19,8 @@ jobs:
       - run: npm ci
 
       - name: Publish
-        run: npm run semantic-release -- --dry-run --debug
+        # for testing, add --dry-run
+        run: npm run semantic-release -- --debug
         env:
           VSCE_PAT: ${{ secrets.PUBLISHER_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
- removed --dry-run option
- restricted action to push on master