### PR TITLE
default devicelist: add common USB Uarts

### DIFF
--- a/package.json
+++ b/package.json
@@ -136,12 +136,12 @@
               "type": "string"
             },
             "default": [
-              "manufacturer=Pycom",
-              "manufacturer=Pycom Ltd.",
+              "manufacturer=Pycom.*",
               "manufacturer=FTDI",
               "manufacturer=Microsoft",
-              "manufacturer=Microchip Technology, Inc.",
-              "manufacturer=1a86"
+              "manufacturer=Microchip Technology.*",
+              "friendlyName=.*CH340.*",
+              "friendlyName=.*CP210.*"
             ],
             "description": "Filter devices to include in the devices list. Uses regular expression. Matches can be done against any property, eg. \"Microsoft\" or against a specific property, eg. \"manufacturer=Microsoft\r\n\r\nFor a list of available devices, run the command \"list devices\"."
           },


### PR DESCRIPTION
add common serial devices and simplify devicelist defaults using regex 