### PR TITLE
logging: 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1298,9 +1298,9 @@
       "integrity": "sha512-Hl219/BT5fLAaz6NDkSuhzasy49dwQS/DSdu4MdggFB8zcXv7vflBI3xp7FEmkmdDkBUI2bPUNeMttp2knYdxw=="
     },
     "@types/vscode": {
-      "version": "1.65.0",
-      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.65.0.tgz",
-      "integrity": "sha512-wQhExnh2nEzpjDMSKhUvnNmz3ucpd3E+R7wJkOhBNK3No6fG3VUdmVmMOKD0A8NDZDDDiQcLNxe3oGmX5SjJ5w==",
+      "version": "1.66.0",
+      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.66.0.tgz",
+      "integrity": "sha512-ZfJck4M7nrGasfs4A4YbUoxis3Vu24cETw3DERsNYtDZmYSYtk6ljKexKFKhImO/ZmY6ZMsmegu2FPkXoUFImA==",
       "dev": true
     },
     "@types/yargs": {

--- a/package.json
+++ b/package.json
@@ -519,7 +519,7 @@
     "@types/glob": "^7.2.0",
     "@types/mocha": "^9.0.0",
     "@types/node": "16.x",
-    "@types/vscode": "^1.63.1",
+    "@types/vscode": "^1.66.0",
     "@vscode/test-electron": "^2.0.3",
     "eslint": "^8.1.0",
     "glob": "^7.1.7",

--- a/package.json
+++ b/package.json
@@ -99,7 +99,7 @@
               "Trace without stacktrace",
               "Trace with stacktrace"
             ],
-            "description": "Defaults to 'info'. Logs can be read in the developer tools (ctrl + shift i)."
+            "description": "Defaults to 'info'. Logs can be read the PyMakr Output Channel (ctrl + shift u), or in the developer tools (ctrl + shift i)."
           },
           "pymakr.debug.logFilter": {
             "type": "string",

--- a/src/Device.js
+++ b/src/Device.js
@@ -207,8 +207,10 @@ class Device {
 
   _onFailedConnectHandler(err) {
     this.connecting = false;
-    const error = [`Failed to connect to ${this.address}.`, err.message, this.adapter];
+    const error = [`Failed to connect to ${this.address}.`, err.message];
     this.log.error(...error);
+    // details to debug log
+    this.log.debug(this.adapter)
     throw error;
   }
 

--- a/src/PyMakr.js
+++ b/src/PyMakr.js
@@ -36,6 +36,8 @@ class PyMakr {
 
     /** Extendable logger. */
     this.log = createLogger("PyMakr");
+    this.log.info(`${manifest.name} v${manifest.version}`);
+
     this.onUpdatedConfig("silent");
     this.context = context;
 

--- a/src/utils/createLogger.js
+++ b/src/utils/createLogger.js
@@ -10,7 +10,7 @@ const util = require('util');
  */
 function data2string(data) {
   if (data instanceof Error) {
-    return data.stack || data.message;
+    return data.message || data.stack || util.inspect(data);
   }
   if (data.success === false && data.message) {
     return data.message;
@@ -46,6 +46,10 @@ const createLogger = (name) => {
         error: (...data) => {
           console.log("error: ", ...data); // in case we need a copy/paste of the console
           outputChannel.appendLine("error: " + data2string(data));
+        },
+        debug: (...data) => {
+          console.log("error: ", ...data); // in case we need a copy/paste of the console
+          outputChannel.appendLine("debug: " + data2string(data));
         },
       },
     },

--- a/src/utils/createLogger.js
+++ b/src/utils/createLogger.js
@@ -1,21 +1,51 @@
 const { createLogger: _createLogger } = require("consolite");
 const vscode = require("vscode");
+const util = require('util');
+
+
+/**
+ * turn log data into a printable string.
+ * @param {any} data
+ * @returns {string}
+ */
+function data2string(data) {
+  if (data instanceof Error) {
+    return data.stack || data.message;
+  }
+  if (data.success === false && data.message) {
+    return data.message;
+  }
+  if (data instanceof Array) {
+    return data.map(data2string).join(" ");
+  }
+  return util.format(data);
+}
+
 
 /**
  * Creates Consolite instance to handle all logging
  * @param {string} name
  */
 const createLogger = (name) => {
-  const outputChannel = vscode.window.createOutputChannel("PyMakr");
+  const outputChannel = vscode.window.createOutputChannel("PyMakr", "log");
 
   const log = _createLogger(
     {
       methods: {
         debugShort: console.log,
         traceShort: console.log,
-        info: (...str) => {
-          console.log("info: ", ...str); // in case we need a copy/paste of the console
-          outputChannel.appendLine(str.join(" "));
+        //todo: add test to check writing to vscode output channel
+        info: (...data) => {
+          console.log("info: ", ...data); // in case we need a copy/paste of the console
+          outputChannel.appendLine("info: " + data2string(data));
+        },
+        warning: (...data) => {
+          console.log("warning: ", ...data); // in case we need a copy/paste of the console
+          outputChannel.appendLine("warning: " + data2string(data));
+        },
+        error: (...data) => {
+          console.log("error: ", ...data); // in case we need a copy/paste of the console
+          outputChannel.appendLine("error: " + data2string(data));
         },
       },
     },


### PR DESCRIPTION
- log extension version at startup to ease error reporting
- convert logs , warning and errors to printable text
Note: possibly may want to limit logging for errors , or send extended info only to debug log.
- specify type as `log` to allow for highlighting using any installed syntax highlighter for logs 