### PR TITLE
feat: Improvements to the user interface

### DIFF
--- a/package.json
+++ b/package.json
@@ -452,8 +452,9 @@
       },
       {
         "command": "pymakr.runEditor",
-        "title": "Run on device",
+        "title": "Run file or selection on device",
         "shortTitle": "Run",
+        "enablement": "editorFocus",
         "category": "PyMakr"
       },
       {

--- a/package.json
+++ b/package.json
@@ -314,7 +314,7 @@
     "viewsWelcome": [
       {
         "view": "pymakr-projects-tree",
-        "contents": "Pymakr 2 uses [multi-root workspaces](https://code.visualstudio.com/docs/editor/workspaces#_multiroot-workspaces) to allow easy access to both project files and devices.\nNo Pymakr projects were found in the current workspace. Please add a project or open an existing workspace.\n\n[Create project](command:pymakr.createProjectPrompt)\n\n[Open Workspace](command:workbench.action.openWorkspace)"
+        "contents": "No Pymakr projects were found in the current workspace. Please add a project or open an existing workspace.\nPymakr 2 uses [multi-root workspaces](https://code.visualstudio.com/docs/editor/workspaces#_multiroot-workspaces) to allow easy access to both project files and devices.\n\n[Create project](command:pymakr.createProjectPrompt)\n\n[Open Workspace](command:workbench.action.openWorkspace)"
       },
       {
         "view": "pymakr-devices-tree",
@@ -350,7 +350,6 @@
       {
         "command": "pymakr.getPymakr",
         "title": "get Pymakr instance (for extension development)",
-        "enablement": "false",
         "category": "PyMakr"
       },
       {
@@ -468,8 +467,13 @@
         "category": "PyMakr"
       },
       {
-        "command": "pymakr.openProjectSettings",
-        "title": "Open the project settings",
+        "command": "pymakr.configureProject",
+        "title": "Configure project",
+        "category": "PyMakr"
+      },
+      {
+        "command": "pymakr.revealDeviceInSidebar",
+        "title": "Show device content in sidebar",
         "category": "PyMakr"
       }
     ],
@@ -520,6 +524,125 @@
       }
     ],
     "menus": {
+      "commandPalette": [
+        {
+          "command": "pymakr.toggleAdvancedMode"
+        },
+        {
+          "command": "pymakr.listDevices"
+        },
+        {
+          "command": "pymakr.createProjectPrompt"
+        },
+        {
+          "command": "pymakr.eraseDevicePrompt",
+          "when": "false"
+        },
+        {
+          "command": "pymakr.createTerminalPrompt",
+          "when": "false"
+        },
+        {
+          "command": "pymakr.createProjectInFolderPrompt",
+          "when": "false"
+        },
+        {
+          "command": "pymakr.getPymakr",
+          "when": "false"
+        },
+        {
+          "command": "pymakr.uploadPrompt",
+          "when": "false"
+        },
+        {
+          "command": "pymakr.runEditor",
+          "when": "false"
+        },
+        {
+          "command": "pymakr.safeBootDevice",
+          "when": "false"
+        },
+        {
+          "command": "pymakr.resetDevice",
+          "when": "false"
+        },
+        {
+          "command": "pymakr.softResetDevice",
+          "when": "false"
+        },
+        {
+          "command": "pymakr.hideDevice",
+          "when": "false"
+        },
+        {
+          "command": "pymakr.showTerminalHistory",
+          "when": "false"
+        },
+        {
+          "command": "pymakr.configureDevice",
+          "when": "false"
+        },
+        {
+          "command": "pymakr.connect",
+          "when": "false"
+        },
+        {
+          "command": "pymakr.addDeviceToFileExplorer",
+          "when": "false"
+        },
+        {
+          "command": "pymakr.newDeviceSerial",
+          "when": "false"
+        },
+        {
+          "command": "pymakr.newDeviceTelnet",
+          "when": "false"
+        },
+        {
+          "command": "pymakr.unhideDevice",
+          "when": "false"
+        },
+        {
+          "command": "pymakr.disconnect",
+          "when": "false"
+        },
+        {
+          "command": "pymakr.downloadProject",
+          "when": "false"
+        },
+        {
+          "command": "pymakr.uploadProject",
+          "when": "false"
+        },
+        {
+          "command": "pymakr.selectDevicesForProjectPrompt",
+          "when": "false"
+        },
+        {
+          "command": "pymakr.removeDeviceFromProject",
+          "when": "false"
+        },
+        {
+          "command": "pymakr.uploadPrompt",
+          "when": "false"
+        },
+        {
+          "command": "pymakr.runEditor",
+          "when": "false"
+        },
+        {
+          "command": "pymakr.runFile",
+          "when": "false"
+        },
+        {
+          "command": "pymakr.configureProject",
+          "when": "false"
+        },
+        {
+          "command": "pymakr.revealDeviceInSidebar",
+          "when": "false"
+        }
+      ],
       "pymakr.newDeviceMenu": [
         {
           "command": "pymakr.newDeviceSerial"
@@ -535,7 +658,7 @@
           "when": "viewItem == project"
         },
         {
-          "command": "pymakr.openProjectSettings",
+          "command": "pymakr.configureProject",
           "group": "1-primary"
         }
       ],
@@ -572,6 +695,10 @@
         },
         {
           "command": "pymakr.configureDevice",
+          "group": "2-config"
+        },
+        {
+          "command": "pymakr.revealDeviceInSidebar",
           "group": "2-config"
         },
         {

--- a/package.json
+++ b/package.json
@@ -439,6 +439,10 @@
       {
         "command": "pymakr.toggleAdvancedMode",
         "title": "Toggle advanced mode"
+      {
+        "command": "pymakr.openProjectSettings",
+        "title": "Open the project settings",
+        "category": "PyMakr"
       }
     ],
     "keybindings": [
@@ -474,6 +478,11 @@
         "label": "device"
       },
       {
+        "id": "pymakr.projectMenu",
+        "icon": "$(ellipsis)",
+        "label": "project"
+      },
+      {
         "id": "pymakr.editorContextMenu",
         "label": "pymakr"
       },
@@ -489,6 +498,17 @@
         },
         {
           "command": "pymakr.newDeviceTelnet"
+        }
+      ],
+      "pymakr.projectMenu": [
+        {
+          "command": "pymakr.selectDevicesForProjectPrompt",
+          "group": "1-primary",
+          "when": "viewItem == project"
+        },
+        {
+          "command": "pymakr.openProjectSettings",
+          "group": "1-primary"
         }
       ],
       "pymakr.projectDeviceMenu": [
@@ -568,11 +588,6 @@
           "when": "viewItem == connectedDevice || viewItem == connectedProjectDevice"
         },
         {
-          "command": "pymakr.selectDevicesForProjectPrompt",
-          "group": "inline",
-          "when": "viewItem == project"
-        },
-        {
           "command": "pymakr.downloadProject",
           "when": "viewItem == connectedProjectDevice",
           "group": "inline@8"
@@ -600,6 +615,11 @@
         {
           "submenu": "pymakr.projectDeviceMenu",
           "when": "viewItem != project",
+          "group": "inline@100"
+        },
+        {
+          "submenu": "pymakr.projectMenu",
+          "when": "viewItem == project",
           "group": "inline@100"
         }
       ],

--- a/package.json
+++ b/package.json
@@ -117,7 +117,8 @@
               "manufacturer=Microsoft",
               "manufacturer=Microchip Technology.*",
               "friendlyName=.*CH34[01].*",
-              "friendlyName=.*CP21.*"
+              "friendlyName=.*CP21.*",
+              "manufacturer=(?!undefined)"
             ],
             "description": "Filter devices to include in the devices list. Uses regular expression. Matches can be done against any property, eg. \"Microsoft\" or against a specific property, eg. \"manufacturer=Microsoft\r\n\r\nFor a list of available devices, run the command \"list devices\"."
           },

--- a/package.json
+++ b/package.json
@@ -318,7 +318,7 @@
       },
       {
         "view": "pymakr-devices-tree",
-        "contents": "Found no devices.\n\nIf you wish to unhide a previously hidden device, select this box and click the ellipsis menu (...). Then select \"Unhide a device\"."
+        "contents": "No devices could be found.\n\n[Unhide a hidden device](command:pymakr.unhideDevice)\n\n[List all devices](command:pymakr.listDevices)"
       }
     ],
     "commands": [

--- a/package.json
+++ b/package.json
@@ -314,7 +314,7 @@
     "viewsWelcome": [
       {
         "view": "pymakr-projects-tree",
-        "contents": "You have no Pymakr projects in your workspace.\n\n[Create project](command:pymakr.createProjectPrompt)"
+        "contents": "Pymakr 2 uses [multi-root workspaces](https://code.visualstudio.com/docs/editor/workspaces#_multiroot-workspaces) to allow easy access to both project files and devices.\nNo Pymakr projects were found in the current workspace. Please add a project or open an existing workspace.\n\n[Create project](command:pymakr.createProjectPrompt)\n\n[Open Workspace](command:workbench.action.openWorkspace)"
       },
       {
         "view": "pymakr-devices-tree",

--- a/package.json
+++ b/package.json
@@ -324,121 +324,149 @@
     "commands": [
       {
         "command": "pymakr.listDevices",
-        "title": "List devices"
+        "title": "List devices",
+        "category": "PyMakr"
       },
       {
         "command": "pymakr.safeBootDevice",
-        "title": "Safe boot device"
+        "title": "Safe boot device",
+        "category": "PyMakr"
       },
       {
         "command": "pymakr.resetDevice",
-        "title": "Hard reset device"
+        "title": "Hard reset device",
+        "category": "PyMakr"
       },
       {
         "command": "pymakr.softResetDevice",
-        "title": "Soft reset device"
+        "title": "Soft reset device",
+        "category": "PyMakr"
       },
       {
         "command": "pymakr.eraseDevicePrompt",
-        "title": "Erase device"
+        "title": "Erase device",
+        "category": "PyMakr"
       },
       {
         "command": "pymakr.getPymakr",
-        "title": "get Pymakr instance (for extension development)"
+        "title": "get Pymakr instance (for extension development)",
+        "enablement": "false",
+        "category": "PyMakr"
       },
       {
         "command": "pymakr.hideDevice",
-        "title": "Hide device"
+        "title": "Hide device",
+        "category": "PyMakr"
       },
       {
         "command": "pymakr.showTerminalHistory",
-        "title": "Open terminal history"
+        "title": "Open terminal history",
+        "category": "PyMakr"
       },
       {
         "command": "pymakr.createProjectInFolderPrompt",
         "title": "Create project in folder",
-        "icon": "$(plus)"
+        "icon": "$(plus)",
+        "category": "PyMakr"
       },
       {
         "command": "pymakr.createProjectPrompt",
         "title": "Create new project",
-        "icon": "$(plus)"
+        "icon": "$(plus)",
+        "category": "PyMakr"
       },
       {
         "command": "pymakr.configureDevice",
-        "title": "Configure device"
+        "title": "Configure device",
+        "category": "PyMakr"
       },
       {
         "command": "pymakr.connect",
         "title": "Connect device",
-        "icon": "$(zap)"
+        "icon": "$(zap)",
+        "category": "PyMakr"
       },
       {
         "command": "pymakr.addDeviceToFileExplorer",
         "title": "Open device in file explorer",
-        "icon": "$(folder)"
+        "icon": "$(folder)",
+        "category": "PyMakr"
       },
       {
         "command": "pymakr.newDeviceSerial",
-        "title": "Serial"
+        "title": "Serial",
+        "category": "PyMakr"
       },
       {
         "command": "pymakr.newDeviceTelnet",
-        "title": "Telnet"
+        "title": "Telnet",
+        "category": "PyMakr"
       },
       {
         "command": "pymakr.unhideDevice",
-        "title": "Unhide a device"
+        "title": "Unhide a device",
+        "category": "PyMakr"
       },
       {
         "command": "pymakr.createTerminalPrompt",
         "title": "Create terminal",
-        "icon": "$(terminal-view-icon)"
+        "icon": "$(terminal-view-icon)",
+        "category": "PyMakr"
       },
       {
         "command": "pymakr.disconnect",
         "title": "Disconnect device",
-        "icon": "$(debug-disconnect)"
+        "icon": "$(debug-disconnect)",
+        "category": "PyMakr"
       },
       {
         "command": "pymakr.downloadProject",
         "shortTitle": "Download",
         "title": "Download project from device",
-        "icon": "$(cloud-download)"
+        "icon": "$(cloud-download)",
+        "category": "PyMakr"
       },
       {
         "command": "pymakr.uploadProject",
         "shortTitle": "Upload",
         "title": "Sync project to device",
-        "icon": "$(cloud-upload)"
+        "icon": "$(cloud-upload)",
+        "category": "PyMakr"
       },
       {
         "command": "pymakr.selectDevicesForProjectPrompt",
         "shortTitle": "$(plus)device",
-        "title": "Select devices"
+        "title": "Select devices",
+        "category": "PyMakr"
       },
       {
         "command": "pymakr.removeDeviceFromProject",
         "title": "Remove device from project",
-        "shortTitle": "Remove device"
+        "shortTitle": "Remove device",
+        "category": "PyMakr"
       },
       {
         "command": "pymakr.uploadPrompt",
-        "title": "Upload to device"
+        "title": "Upload to device",
+        "category": "PyMakr"
       },
       {
         "command": "pymakr.runEditor",
         "title": "Run on device",
-        "shortTitle": "Run"
+        "shortTitle": "Run",
+        "category": "PyMakr"
       },
       {
         "command": "pymakr.runFile",
         "title": "Run file on device",
-        "shortTitle": "Run"
+        "shortTitle": "Run",
+        "category": "PyMakr"
       },
       {
         "command": "pymakr.toggleAdvancedMode",
-        "title": "Toggle advanced mode"
+        "title": "Toggle advanced mode",
+        "category": "PyMakr"
+      },
       {
         "command": "pymakr.openProjectSettings",
         "title": "Open the project settings",

--- a/src/Device.js
+++ b/src/Device.js
@@ -90,10 +90,11 @@ class Device {
     if (!this.config.hidden) this.updateConnection();
     subscribe(() => this.onChanged());
 
-    this.busy.subscribe((val) => this.log.info(val ? "busy..." : "idle."));
+    this.busy.subscribe((val) => this.log.debugShort(val ? "busy..." : "idle."));
 
     this.readUntil = createReadUntil();
     this.readUntil(/\n>>> [^\n]*$/, (matches) => this.busy.set(!matches), { callOnFalse: true });
+
   }
 
   applyCustomDeviceConfig() {
@@ -143,7 +144,7 @@ class Device {
       const isChanged = JSON.stringify(pymakrConf) !== JSON.stringify(this.pymakrConf);
       this.pymakrConf = pymakrConf;
       return isChanged;
-    } catch (err) {}
+    } catch (err) { }
   }
 
   /**
@@ -178,7 +179,7 @@ class Device {
    * Therefore any wrapping or extending of this method will be lost whenever a terminal is used
    * @param {string} data
    */
-  __onTerminalDataExclusive(data) {}
+  __onTerminalDataExclusive(data) { }
 
   /**
    * Auto connects device if required by user preferences

--- a/src/commands/index.js
+++ b/src/commands/index.js
@@ -11,6 +11,7 @@ const {
   waitFor,
 } = require("../utils/misc");
 const { relative } = require("path");
+const { Project } = require("../Project");
 
 /**
  * Commands contains all commands that can be accessed through VSCode.
@@ -37,8 +38,7 @@ class Commands {
           await value.bind(this)(...params);
         } catch (err) {
           vscode.window.showErrorMessage(
-            `[Pymakr] Failed to run command: ${key}. Reason: ${
-              err.message || err.name || err
+            `[Pymakr] Failed to run command: ${key}. Reason: ${err.message || err.name || err
             }. Please see logs for info.`
           );
           this.log.error(`Failed to run command: ${key} with params:`, params);
@@ -336,6 +336,25 @@ class Commands {
       const advancedMode = vscode.workspace.getConfiguration("pymakr").get("advancedMode");
       this.pymakr.config.get().update("advancedMode", !advancedMode);
     },
+
+    /**
+     * Opens the selected project settins in the editor
+     * @param {ProjectTreeItem} treeItem
+     * @returns {Promise<any>}
+     */
+    openProjectSettings: async (treeItem) => {
+      if (!treeItem) {
+        return;
+      }
+      if (!treeItem.project.folder) {
+        return;
+      }
+      let uri = vscode.Uri.file(treeItem.project.folder + "/pymakr.conf");
+      this.log.debug(`Revealing ${uri.fsPath} in explorer`);
+      await vscode.commands.executeCommand("revealInExplorer", uri);
+      await vscode.commands.executeCommand("vscode.open", uri, );
+    },
+
     /**
      * Runs the currently selected editor code on the device. If no code is selected, all code is ran.
      */
@@ -484,7 +503,7 @@ class Commands {
     },
 
     // todo remove
-    newDeviceRecover: async () => {},
+    newDeviceRecover: async () => { },
 
     /**
      * Uploads parent project to the device. Can only be accessed from devices in the projects view.

--- a/src/commands/index.js
+++ b/src/commands/index.js
@@ -346,13 +346,11 @@ class Commands {
       if (!treeItem) {
         return;
       }
-      if (!treeItem.project.folder) {
-        return;
-      }
-      let uri = vscode.Uri.file(treeItem.project.folder + "/pymakr.conf");
+      const project = this.pymakr.vscodeHelpers.coerceProject(treeItem);
+      const uri = vscode.Uri.file(project.folder + "/pymakr.conf");
       this.log.debug(`Revealing ${uri.fsPath} in explorer`);
       await vscode.commands.executeCommand("revealInExplorer", uri);
-      await vscode.commands.executeCommand("vscode.open", uri, );
+      await vscode.commands.executeCommand("vscode.open", uri,);
     },
 
     /**

--- a/src/commands/index.js
+++ b/src/commands/index.js
@@ -342,7 +342,7 @@ class Commands {
      * @param {ProjectTreeItem} treeItem
      * @returns {Promise<any>}
      */
-    openProjectSettings: async (treeItem) => {
+    configureProject: async (treeItem) => {
       if (!treeItem) {
         return;
       }
@@ -350,7 +350,7 @@ class Commands {
       const uri = vscode.Uri.file(project.folder + "/pymakr.conf");
       this.log.debug(`Revealing ${uri.fsPath} in explorer`);
       await vscode.commands.executeCommand("revealInExplorer", uri);
-      await vscode.commands.executeCommand("vscode.open", uri,);
+      await vscode.commands.executeCommand("vscode.open", uri);
     },
 
     /**
@@ -630,6 +630,7 @@ class Commands {
      * @param {ProjectDeviceTreeItem} treeItem
      */
     addDeviceToFileExplorer: async ({ device }) => {
+      // Todo: move to utlis
       const uri = vscode.Uri.from({
         scheme: device.protocol,
         // vscode doesn't like "/" in the authority name
@@ -642,9 +643,28 @@ class Commands {
       const wsPos = vscode.workspace.workspaceFolders?.length || 0;
       vscode.workspace.updateWorkspaceFolders(wsPos, 0, { uri, name });
 
+      vscode.commands.executeCommand("revealInExplorer", uri);
       return this.pymakr.vscodeHelpers.showAddDeviceToFileExplorerProgressBar();
     },
+
+    /**
+     * Navigate to a mounted device in the explorer view
+     * @param {ProjectDeviceTreeItem} treeItem
+     */
+    revealDeviceInSidebar: async ({ device }) => {
+      // Todo: move to utlis
+      const uri = vscode.Uri.from({
+        scheme: device.protocol,
+        // vscode doesn't like "/" in the authority name
+        authority: device.address.replace(/\//g, "%2F"),
+        path: device.rootPath,
+      });
+      // todo: this does not reliably set 
+      vscode.commands.executeCommand("revealInExplorer", uri);
+    },
   };
+
+
 }
 
 module.exports = { Commands };

--- a/src/utils/StateManager.js
+++ b/src/utils/StateManager.js
@@ -29,7 +29,6 @@ class StateManager {
   save() {
     const value = this._cb();
     this._context.workspaceState.update(this._id, value);
-    // todo: avoid logging passwords in the output channel
     this.log.debugShort("save", this._id, value);
     return this.load();
   }
@@ -40,7 +39,6 @@ class StateManager {
    */
   load() {
     const value = this._context.workspaceState.get(this._id) || {};
-    // todo: avoid logging passwords in the output channel
     this.log.debugShort("load", this._id, value);
     return value;
   }

--- a/src/utils/StateManager.js
+++ b/src/utils/StateManager.js
@@ -29,7 +29,7 @@ class StateManager {
   save() {
     const value = this._cb();
     this._context.workspaceState.update(this._id, value);
-
+    // todo: avoid logging passwords in the output channel
     this.log.debugShort("save", this._id, value);
     return this.load();
   }
@@ -40,6 +40,7 @@ class StateManager {
    */
   load() {
     const value = this._context.workspaceState.get(this._id) || {};
+    // todo: avoid logging passwords in the output channel
     this.log.debugShort("load", this._id, value);
     return value;
   }

--- a/src/utils/createLogger.js
+++ b/src/utils/createLogger.js
@@ -18,7 +18,8 @@ function data2string(data) {
   if (data instanceof Array) {
     return data.map(data2string).join(" ");
   }
-  return util.format(data);
+  // replace passwords in json with ****
+  return util.format(data).replace(/password: '.*?'/g, "password: '****'");
 }
 
 
@@ -29,12 +30,12 @@ function data2string(data) {
 const createLogger = (name) => {
   const outputChannel = vscode.window.createOutputChannel("PyMakr", "log");
   const now = Date.now()
-
+  // todo: add test to check writing to vscode output channel
+  // todo: avoid logging passwords in the console log
   const log = _createLogger(
     {
       methods: {
         traceShort: console.log,
-        //todo: add test to check writing to vscode output channel
         info: (...data) => {
           console.log("info: ", ...data); // in case we need a copy/paste of the console
           outputChannel.appendLine("info: " + data2string(data));

--- a/src/utils/createLogger.js
+++ b/src/utils/createLogger.js
@@ -33,7 +33,6 @@ const createLogger = (name) => {
   const log = _createLogger(
     {
       methods: {
-        debugShort: console.log,
         traceShort: console.log,
         //todo: add test to check writing to vscode output channel
         info: (...data) => {
@@ -48,13 +47,17 @@ const createLogger = (name) => {
           console.log("error: ", ...data); // in case we need a copy/paste of the console
           outputChannel.appendLine("error: " + data2string(data));
         },
+        debugShort: (...data) => {
+          console.log("debug: ", ...data); // in case we need a copy/paste of the console
+          outputChannel.appendLine("debug: " + data2string(data));
+        },
         debug: (...data) => {
           console.log("debug: ", ...data); // in case we need a copy/paste of the console
           outputChannel.appendLine("debug: " + data2string(data));
         },
       },
     },
-    ()=> `${name} (${Date.now() - now})`
+    () => `${name} (${Date.now() - now})`
   );
 
   log.levels = {


### PR DESCRIPTION
I have a few improvements to the UX that I would like to propose. 
Most are based on my experience in trying to understand how to switch from Pymakr1 to Pymakr 2 

- [x] add a hint and an action that users may want to open an existing workspace
- [x] add a button to list / unhide devices on an empty device list 
- project
  - [x] add a menu option on Projects to allows changing the project options (in the projects pymakr.cfg) 
- commands 
  - [x] add labeling for all **pymakr** commands so they can be searched for 
  - [x] hide the test menu item `get Pymakr instance (for extension development)`
  - [x] hide commands that cannot be directly executed from the commandPalette, to avoid errors such as :   
  `[Pymakr] Failed to run command: downloadProject. Reason: Cannot read properties of undefined (reading 'device'). Please see logs for info. `
- device workspace 
  - [x] after adding device to the workspace, reveal the folder in the navigation
  - [x] add navigation from device to folder in workspace ( as names are/can be very differently formatted) 
- [x] avoid logging passwords to Output Channel


![image](https://user-images.githubusercontent.com/981654/169658482-d691bd8a-70ba-4fce-8047-9fa4495600c7.png)

![image](https://user-images.githubusercontent.com/981654/169658404-db67b5ee-a660-4e49-a7ee-95f31403c68f.png)

![image](https://user-images.githubusercontent.com/981654/169668846-eb89ae31-ba70-4958-9cff-7f8e84472a4f.png)

![image](https://user-images.githubusercontent.com/981654/169668070-30ce34b3-5060-47da-915e-ea22e0e15a99.png)

![image](https://user-images.githubusercontent.com/981654/169995125-d68b5486-b4b5-4350-a8fc-3d9c996d84e1.png)
