### PR TITLE
Root path

### DIFF
--- a/package.json
+++ b/package.json
@@ -175,11 +175,6 @@
             },
             "default": [
               {
-                "match": "manufacturer=.*",
-                "field": "rootPath",
-                "value": "/flash"
-              },
-              {
                 "match": "serialNumber=Example1234",
                 "field": "rootPath",
                 "value": "/custom/path"

--- a/src/Device.js
+++ b/src/Device.js
@@ -382,6 +382,7 @@ class Device {
   onChanged() {
     this.applyCustomDeviceConfig();
     this.stateManager.save();
+    this.log.traceShort("Changed. Refreshing providers.");
     // throttle the UI refresh call. This makes sure that multiple devices doesn't trigger the same call.
     this.pymakr.refreshProvidersThrottled();
   }

--- a/src/commands/index.js
+++ b/src/commands/index.js
@@ -140,7 +140,7 @@ class Commands {
       if (picked && picked.length) {
         picked.forEach(({ device }) => {
           device.config.hidden = false;
-          device.state.save();
+          device.stateManager.save();
         });
         this.pymakr.devicesProvider.refresh();
         this.pymakr.projectsProvider.refresh();
@@ -152,7 +152,7 @@ class Commands {
      */
     hideDevice: ({ device }) => {
       device.config.hidden = true;
-      device.state.save();
+      device.stateManager.save();
       this.pymakr.devicesProvider.refresh();
       this.pymakr.projectsProvider.refresh();
     },
@@ -320,7 +320,7 @@ class Commands {
             let { label, clear } = await vscode.window.showQuickPick(options);
             if (clear) label = null;
             device.config.autoConnect = label;
-            device.state.save();
+            device.stateManager.save();
             return "main";
           },
         };


### PR DESCRIPTION
This PR auto detects the root path of devices, Pycom and third party.

I'm not a fan of using VSCode's `workspaceState` for this.

| |workspace|global|
|---|---|---|
|**config**|`WorkspaceConfiguration.update('field', value)`|`WorkspaceConfiguration.update('field', value, true)`|
|**state**|`ExtensionContext.workspaceState`|`ExtensionContext.globalState`|

Currently we use workspaceState for managing devices, but as the project grows, this could prove counter productive. If we switch to using configs rather than state, we may have greater control over which level (workspace vs global) at which we store data. This is predicated on workspace + global configs deep merging on retrieval. This is likely not the case, but is worth investigating.

At any rate, it might be time to consider a more flexible approach to storing state / config.