### PR TITLE
Refactor config and state

### DIFF
--- a/package.json
+++ b/package.json
@@ -144,6 +144,54 @@
             "type": "string",
             "default": "{displayName} / {projectName}"
           },
+          "pymakr.devices.configs": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "autoConnect": {
+                  "type": "string",
+                  "enum": [
+                    "always",
+                    "never",
+                    "onLostConnection",
+                    "lastState"
+                  ],
+                  "enumDescriptions": [
+                    "Always auto connect to devices.",
+                    "Never auto connect to devices.",
+                    "Only auto connect to devices if connection was previously lost.",
+                    "Auto connect to devices that were never manually disconnected."
+                  ],
+                  "description": "When to connect devices automatically. Setting can be superseded on device level, by right clicking the device and selecting 'config'."
+                },
+                "name": {
+                  "type": "string",
+                  "description": "name of device."
+                },
+                "username": {
+                  "type": "string",
+                  "description": "Not currently used."
+                },
+                "password": {
+                  "type": "string",
+                  "description": "Not currently used."
+                },
+                "hidden": {
+                  "type": "boolean",
+                  "description": "Hide device from showing in the devices view."
+                },
+                "rootPath": {
+                  "type": "string",
+                  "description": "Commonly \"/flash\", \"/\" or \"/sd\"."
+                },
+                "id": {
+                  "type": "string",
+                  "description": "ID of device. Do not change unless you know what you're doing."
+                }
+              }
+            }
+          },
           "pymakr.devices.config": {
             "type": "array",
             "items": {

--- a/src/Project.js
+++ b/src/Project.js
@@ -22,8 +22,8 @@ class Project {
       this.pymakr.log.error("could not parse config:", configFile.fsPath);
       vscode.window.showErrorMessage(this.err);
     }
-    (this.deviceIds = createStateObject(pymakr.context.globalState, `project.${this.folder}`, [])),
-      (this.name = this.config.name || basename(this.folder));
+    this.deviceIds = createStateObject(pymakr.context.globalState, `project.${this.folder}`, []);
+    this.name = this.config.name || basename(this.folder);
     this.log = pymakr.log.createChild("project: " + this.name);
   }
 

--- a/src/Project.js
+++ b/src/Project.js
@@ -1,7 +1,8 @@
 const { readFileSync } = require("fs");
 const { dirname, basename } = require("path");
 const vscode = require("vscode");
-const { StateManager } = require("./utils/StateManager");
+const { StateManager2 } = require("./utils/StateManager2");
+const { createStateObject } = require("./utils/storageObj");
 
 class Project {
   /**
@@ -21,31 +22,13 @@ class Project {
       this.pymakr.log.error("could not parse config:", configFile.fsPath);
       vscode.window.showErrorMessage(this.err);
     }
-
-    this.state = this.createState();    
-    this.name = this.config.name || basename(this.folder);
+    (this.deviceIds = createStateObject(pymakr.context.globalState, `project.${this.folder}`, [])),
+      (this.name = this.config.name || basename(this.folder));
     this.log = pymakr.log.createChild("project: " + this.name);
-
-    /** @type {import('./Device').Device[]} */
-    this.devices = [];
-    this.recoverProject();
   }
 
-  /**
-   * Restore/reattach devices from last session
-   */
-  recoverProject() {
-    const deviceIds = this.state.load().devices || [];
-    this.devices = this.pymakr.devicesStore.getAllById(deviceIds);
-  }
-
-  /**
-   * Creates a state manager, that can save and load project state from VSCode's workspace state
-   * The saved data is determined by the callback provided to the StateManager constructor
-   */
-  createState() {
-    const createStateObj = () => ({ devices: this.devices.map((device) => device.id) });
-    return new StateManager(this.pymakr, `projects.${this.folder}`, createStateObj);
+  get devices() {
+    return this.pymakr.devicesStore.getAllById(this.deviceIds.get());
   }
 
   /**
@@ -53,9 +36,9 @@ class Project {
    * @param {import('./Device').Device[]} devices
    */
   setDevices(devices) {
-    this.devices = [...devices]
+    const deviceIds = devices.map(({ id }) => id);
+    this.deviceIds.set(deviceIds);
     this.pymakr.projectsProvider.refresh();
-    this.state.save();
   }
 }
 

--- a/src/PyMakr.js
+++ b/src/PyMakr.js
@@ -113,17 +113,8 @@ class PyMakr {
    */
   async setup() {
     await Promise.all([this.devicesStore.registerUSBDevices(), this.registerProjects()]);
-    await this.recoverProjects();
     this.projectsProvider.refresh(); // tell the provider that projects were updated
     this.context.subscriptions.push(coerceDisposable(this.devicesStore.watchUSBDevices()));
-  }
-
-  /**
-   * Recovers each project in the store to its state in the last session, if such exists.
-   * This reattaches devices.
-   */
-  async recoverProjects() {
-    return Promise.all(this.projectsStore.get().map((project) => project.recoverProject()));
   }
 
   /**

--- a/src/commands/index.js
+++ b/src/commands/index.js
@@ -116,7 +116,7 @@ class Commands {
           progress.report({ message: "Erasing device" });
           try {
             const templatePath = `${__dirname}/../../templates/${templateId}`;
-            await device.adapter.remove(device.rootPath, true);
+            await device.adapter.remove(device.config.rootPath, true);
             await this.commands.upload({ fsPath: templatePath }, device, "/");
             resolve();
           } catch (err) {
@@ -314,8 +314,7 @@ class Commands {
 
             let { label, clear } = await vscode.window.showQuickPick(options);
             if (clear) label = null;
-            device.config.autoConnect = label;
-            device.state.save();
+            device.config = {...device.config, autoConnect: label}
             return "main";
           },
         };
@@ -520,7 +519,7 @@ class Commands {
      * @param {ProjectDeviceTreeItem} treeItem
      */
     uploadProject: async ({ device, project }) => {
-      await device.adapter.remove(device.rootPath, true);
+      await device.adapter.remove(device.config.rootPath, true);
       this.commands.upload({ fsPath: project.folder }, device, "/");
     },
 
@@ -580,7 +579,7 @@ class Commands {
      * @param {Partial<ProjectDeviceTreeItem>} treeItem
      */
     downloadProject: async (treeItem) => {
-      const regex = new RegExp(`^${treeItem.device.rootPath}`);
+      const regex = new RegExp(`^${treeItem.device.config.rootPath}`);
       const SourceFilesAndDirs = await treeItem.device.adapter.listFiles("", { recursive: true });
       const filesAndDirs = SourceFilesAndDirs.map((fad) => ({
         ...fad,
@@ -637,7 +636,7 @@ class Commands {
         scheme: device.protocol,
         // vscode doesn't like "/" in the authority name
         authority: device.address.replace(/\//g, "%2F"),
-        path: device.rootPath,
+        path: device.config.rootPath,
       });
 
       const name = `${device.protocol}:/${device.address}`;

--- a/src/providers/FilesystemProvider.js
+++ b/src/providers/FilesystemProvider.js
@@ -95,7 +95,7 @@ class FileSystemProvider {
   async readDirectory(uri) {
     this.log.debug("read dir", uri.path);
     const device = this._getDevice(uri);
-    const path = uri.path.startsWith(device.rootPath) ? uri.path : device.rootPath;
+    const path = uri.path.startsWith(device.config.rootPath) ? uri.path : device.config.rootPath;
 
     try {
       const files = await device.adapter.listFiles(path, { recursive: false });

--- a/src/stores/devices.js
+++ b/src/stores/devices.js
@@ -73,7 +73,7 @@ const createDevicesStore = (pymakr) => {
       device.online = inputIds.includes(device.id);
 
       // if status has changed, update connection
-      if (device.online !== _lastOnlineState) device.updateConnection();
+      if (device.online && !device.config.hidden && !_lastOnlineState) device.refreshConnection();
     });
   };
 

--- a/src/utils/StateManager.js
+++ b/src/utils/StateManager.js
@@ -1,3 +1,6 @@
+// todo delete
+// @deprecated
+
 /**
  * @template R
  */

--- a/src/utils/StateManager2.js
+++ b/src/utils/StateManager2.js
@@ -1,0 +1,82 @@
+// todo delete
+// @deprecated
+
+const vscode = require("vscode");
+
+/**
+ * @template R
+ */
+class StateManager2 {
+  /**
+   * State object that can be saved to VSCode's workspaceState
+   * Uses callback to generate state object when save is called()
+   * @param {PyMakr} pymakr
+   * @param {string} section namespace of state/config object
+   * @param {string} subSection id of state/config object
+   * */
+  constructor(pymakr, section = "pymakr", subSection) {
+    /** @private */
+    this.pymakr = pymakr;
+    /** @private */
+    this.log = pymakr.log.createChild("stateManager2");
+    /** @private */
+    this._context = pymakr.context;
+    this.section = section;
+    this.subSection = subSection;
+  }
+
+  /**
+   * Fetches the state from the provided callback and saves it to VSCode's workspaceState
+   * @param {*} value
+   * @param {'workspaceState'|'globalState'|'workspaceConfig'|'workspaceFolderConfig'|'globalConfig'} location
+   * @param {string=} field
+   */
+  save(value, location, field) {
+    const fieldSuffix = field ? `.${field}` : "";
+    const subsection = `${this.subSection}${fieldSuffix}`;
+    const isGlobal = location === "globalConfig" || location === "globalState";
+    const isConfig =
+      location === "globalConfig" || location === "workspaceConfig" || location === "workspaceFolderConfig";
+    if (isConfig) {
+      const target = isGlobal
+        ? vscode.ConfigurationTarget.Global
+        : location === "workspaceConfig"
+        ? vscode.ConfigurationTarget.Workspace
+        : vscode.ConfigurationTarget.WorkspaceFolder;
+      vscode.workspace.getConfiguration(this.section).update(subsection, value, target);
+    } else {
+      const section = `${this.section}.${this.subSection}${fieldSuffix}`;
+      if (isGlobal) {
+        this._context.globalState.update(section, value);
+      } else {
+        this._context.workspaceState.update(section, value);
+      }
+    }
+    // this._context.
+    this.log.debugShort("save", this.subSection, field, value);
+    return this.load(field);
+  }
+
+  /**
+   * Loads the state from VSCode's workspaceState
+   * @param {string} field
+   * @returns {R}
+   */
+  load(field) {
+    const fieldSuffix = field ? `.${field}` : ``;
+    const subSection = `${this.subSection}${fieldSuffix}`;
+
+    const value = vscode.workspace.getConfiguration(this.section).get(subSection) || {};
+    if (typeof value === "object")
+      Object.assign(
+        value,
+        this._context.globalState.get(`${this.section}.${this.subSection}${fieldSuffix}`),
+        this._context.workspaceState.get(`${this.section}.${this.subSection}${fieldSuffix}`)
+      );
+
+    this.log.debugShort("load", subSection, value);
+    return value;
+  }
+}
+
+module.exports = { StateManager2 };

--- a/src/utils/createLogger.js
+++ b/src/utils/createLogger.js
@@ -9,6 +9,7 @@ const util = require('util');
  * @returns {string}
  */
 function data2string(data) {
+  if (!data) return JSON.stringify(data);
   if (data instanceof Error) {
     return data.message || data.stack || util.inspect(data);
   }

--- a/src/utils/storageObj.js
+++ b/src/utils/storageObj.js
@@ -1,0 +1,85 @@
+const vscode = require("vscode");
+
+/** @typedef {Boolean} Changed */
+
+/**
+ * @template T
+ * @typedef {Object} GetterSetter
+ * @prop {()=>T} get
+ * @prop {function(T):Changed} set
+ */
+
+/**
+ * @template T
+ * @param {vscode.Memento} stateStorage
+ * @param {string} key
+ * @param {T=} defaults
+ * @returns {GetterSetter<T>}
+ */
+const createStateObject = (stateStorage, key, defaults) => {
+  const get = () => stateStorage.get(key) ?? defaults;
+  const set = (value) => {
+    const changed = JSON.stringify(get()) !== JSON.stringify(value);
+    stateStorage.update(key, value);
+    return changed;
+  };
+  return { get, set };
+};
+
+/**
+ * @template T
+ * @param {string} section configuration name, supports dotted
+ * @param {string} key key name, supports dotted
+ * @param {T=} defaults
+ * @param {vscode.ConfigurationTarget=} configurationTarget
+ * @returns {GetterSetter<T>}
+ */
+const createConfigObject = (section, key, defaults, configurationTarget = vscode.ConfigurationTarget.Global) => {
+  const get = () => vscode.workspace.getConfiguration(section).get(key) || defaults;
+  const set = (value) => {
+    const changed = JSON.stringify(get()) !== JSON.stringify(value);
+    vscode.workspace.getConfiguration(section).update(key, value, configurationTarget);
+    return changed;
+  };
+  return { get, set };
+};
+
+/**
+ * @template T
+ * @param {string} section configuration name, supports dotted
+ * @param {string} key key name, supports dotted
+ * @param {string} id key name, supports dotted
+ * @param {T=} defaults
+ * @param {vscode.ConfigurationTarget=} configurationTarget
+ * @returns {GetterSetter<T>}
+ */
+const createListedConfigObject = (
+  section,
+  key,
+  id,
+  defaults,
+  configurationTarget = vscode.ConfigurationTarget.Global
+) => {
+  console.log('set', section, key, id)
+  const get = () =>
+    vscode.workspace
+      .getConfiguration(section)
+      .get(key)
+      .find((cfg) => cfg.id === id) || defaults;
+  const set = async (value) => {
+    /** @type {Array} */
+    const all = vscode.workspace.getConfiguration(section).get(key);
+    const index = all.findIndex((e) => e.id === id);
+    const old = get();
+    value.id = id;
+    old.id = id;
+    const changed = JSON.stringify(old) !== JSON.stringify(value);
+    if (index > -1) all[index] = value;
+    else all.push(value);
+    await vscode.workspace.getConfiguration(section).update(key, all, configurationTarget);
+    return changed;
+  };
+  return { get, set };
+};
+
+module.exports = { createStateObject, createConfigObject, createListedConfigObject };

--- a/test/suite/integration/file-management/file-management.test.js
+++ b/test/suite/integration/file-management/file-management.test.js
@@ -8,45 +8,45 @@ test("file management", async () => {
 
   test("can clear device", async () => {
     await device.connect();
-    await device.adapter.remove(device.rootPath, true);
-    const files = await device.adapter.listFiles(device.rootPath, { recursive: false });
+    await device.adapter.remove(device.config.rootPath, true);
+    const files = await device.adapter.listFiles(device.config.rootPath, { recursive: false });
     assert.deepEqual(files, []);
   });
 
   test("can upload a file", async () => {
     const uri = vscode.Uri.file(join(__dirname, "_sample/sample-file-1.md"));
     await pymakr.commands.upload(uri, device, "/sample-file-1.md");
-    const files = await device.adapter.listFiles(device.rootPath, { recursive: false });
+    const files = await device.adapter.listFiles(device.config.rootPath, { recursive: false });
     assert.equal(files.length, 1);
-    assert.equal(files[0].filename, posix.join(device.rootPath, "/sample-file-1.md"));
+    assert.equal(files[0].filename, posix.join(device.config.rootPath, "/sample-file-1.md"));
   });
 
   test("can upload a dir", async () => {
     const uri = vscode.Uri.file(__dirname + "/_sample");
     await pymakr.commands.upload(uri, device, "/");
-    const files = await device.adapter.listFiles(device.rootPath, { recursive: false });
+    const files = await device.adapter.listFiles(device.config.rootPath, { recursive: false });
     assert.deepEqual(
       files.map((f) => f.filename),
       [
-        posix.join(device.rootPath, "includeme"),
-        posix.join(device.rootPath, "main.py"),
-        posix.join(device.rootPath, "pymakr.conf"),
-        posix.join(device.rootPath, "sample-file-1.md"),
-        posix.join(device.rootPath, "sample-file-2.md"),
+        posix.join(device.config.rootPath, "includeme"),
+        posix.join(device.config.rootPath, "main.py"),
+        posix.join(device.config.rootPath, "pymakr.conf"),
+        posix.join(device.config.rootPath, "sample-file-1.md"),
+        posix.join(device.config.rootPath, "sample-file-2.md"),
       ]
     );
   });
 
   test("can erase and provision a device", async () => {
     await pymakr.commands.eraseDevice({ device }, "empty");
-    const files = await device.adapter.listFiles(device.rootPath, { recursive: false });
+    const files = await device.adapter.listFiles(device.config.rootPath, { recursive: false });
     assert.equal(files.length, 3);
     assert.deepEqual(
       files.map((f) => f.filename),
       [
-        posix.join(device.rootPath, "boot.py"),
-        posix.join(device.rootPath, "main.py"),
-        posix.join(device.rootPath, "pymakr.conf"),
+        posix.join(device.config.rootPath, "boot.py"),
+        posix.join(device.config.rootPath, "main.py"),
+        posix.join(device.config.rootPath, "pymakr.conf"),
       ]
     );
   });


### PR DESCRIPTION
This PR organizes state and configs better than the old state manager.

- It gets rid of state and config mutation
- Each config or state entry now has its own store. These can be extended if needed
- There's now a clear distinction between what data lives in VSCode config, VSCode state and a Pymakr session
- Devices each have an entry in the config object at pymakr>devices>configs

The old `pymakr>devices>config` should probably be removed. This feature has never made it into stable, so I think it's okay rename or remove it.
The old `pymakr.config` store should probably be deprecated

For new config / state API, please see: 
https://github.com/pycom/pymakr-vsc/compare/next-staging...refactor-config-and-state?expand=1#diff-e7ad3aaa4e75faf6a5567941fbf5d70863b7d9ef94e4d6aa72b63d2a63dbb4cb